### PR TITLE
version.h not found if not built

### DIFF
--- a/deadwood/Dockerfile
+++ b/deadwood/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 RUN apk update && apk add git gcc make libc-dev gettext
 RUN mkdir /tmp/deadwood && cd /tmp/deadwood \
     && git clone https://github.com/samboy/MaraDNS \
-    && cd MaraDNS/deadwood-github/src && make \
+    && cd MaraDNS/deadwood-github/src && make version.h && make Deadwood \
     && mkdir -p /opt/deadwood && cp Deadwood /opt/deadwood
 
 COPY dwoodrc.tpl /opt/deadwood


### PR DESCRIPTION
Tried to do a docker build, got an error missing version.h.  Looked at the makefile, and updated your Dockerfile.
